### PR TITLE
Add WebCanvas evaluation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
         run: |
           pip install --no-cache-dir -r requirements.txt
           playwright install --with-deps chromium
+      - name: Run tests
+        run: pytest -q
       - name: Run WebArena benchmark
         run: |
           python benchmarks/run_webarena.py --episodes 50 --report results.json
@@ -20,3 +22,17 @@ jobs:
         with:
           name: benchmark
           path: results.json
+      - name: WebCanvas evaluation
+        run: |
+          python -m benchmarks.evaluate_webcanvas \
+            --scenarios benchmarks/webcanvas_scenarios.yaml \
+            --output results/webcanvas_report.csv
+        env:
+          CANVAS_API_KEY: ${{ secrets.CANVAS_API_KEY }}
+      - name: Upload WebCanvas report
+        uses: actions/upload-artifact@v3
+        with:
+          name: webcanvas-results
+          path: results/webcanvas_report.csv
+      - name: Check WebCanvas threshold
+        run: python -m benchmarks.check_threshold results/webcanvas_report.csv

--- a/README.md
+++ b/README.md
@@ -88,7 +88,42 @@ zapisane w katalogu `data/sft`.
 wkrótce
 
 ## Ewaluacja natywnego modelu agenta
-wkrótce
+Automatyczną ewaluację można przeprowadzić przy pomocy WebCanvas.
+
+### Definicja scenariuszy
+Scenariusze testowe są zapisane w pliku `benchmarks/webcanvas_scenarios.yaml`:
+
+```yaml
+- name: login_test
+  url: https://example.com/login
+  success_selector: ".dashboard"
+  max_steps: 5
+  description: Simple login flow
+  credentials:
+    username: user
+    password: pass
+```
+
+Każdy scenariusz musi zawierać `name`, `url`, `success_selector` oraz `max_steps`.
+Opcjonalnie można dodać `description` i `credentials`.
+
+### Uruchamianie lokalne
+Po zainstalowaniu Playwrighta można przeprowadzić ewaluację komendami:
+
+```bash
+playwright install --with-deps
+python -m benchmarks.evaluate_webcanvas \
+  --scenarios benchmarks/webcanvas_scenarios.yaml \
+  --output results/webcanvas_report.csv
+python -m benchmarks.check_threshold results/webcanvas_report.csv
+```
+
+Raport zostanie zapisany w `results/webcanvas_report.csv`.
+
+### Integracja CI
+W ramach workflow GitHub Actions raport z ewaluacji jest tworzony
+automatycznie i publikowany jako artefakt `webcanvas-results`.
+Można go pobrać z zakładki *Actions* po zakończonym przebiegu.
 
 ## Do zrobienia
 - [x] Instrukcja oznaczania danych trajektorii
@@ -96,7 +131,7 @@ wkrótce
 - [x] Przygotowanie danych do SFT – DOM Tree
 - [x] Przygotowanie danych do SFT – Vision
 - [x] Hostowanie lokalnego modelu i inferencja na żywych stronach
-- [ ] Automatyczna ewaluacja z wykorzystaniem WebCanvas
+- [x] Automatyczna ewaluacja z wykorzystaniem WebCanvas
 
 ## Poprzednie rozwiązania
 Przykład ewaluacji agentów sieciowych znajdziesz w repozytorium WebCanvas: [WebCanvas](https://github.com/iMeanAI/WebCanvas)

--- a/benchmarks/check_threshold.py
+++ b/benchmarks/check_threshold.py
@@ -1,0 +1,36 @@
+import argparse
+import csv
+import json
+import sys
+
+
+def read_results(path: str):
+    if path.endswith(".json"):
+        with open(path) as f:
+            return json.load(f)
+    rows = []
+    with open(path, newline="") as f:
+        for row in csv.DictReader(f):
+            row["success"] = str(row["success"]).lower() == "true"
+            rows.append(row)
+    return rows
+
+
+def main(path: str, threshold: float = 0.9) -> None:
+    rows = read_results(path)
+    if not rows:
+        print("No results found")
+        sys.exit(1)
+    success_rate = sum(1 for r in rows if r["success"]) / len(rows)
+    if success_rate < threshold:
+        print(f"Success rate {success_rate:.2f} below threshold {threshold}")
+        sys.exit(1)
+    print(f"Success rate {success_rate:.2f} OK")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path")
+    parser.add_argument("--threshold", type=float, default=0.9)
+    args = parser.parse_args()
+    main(args.path, args.threshold)

--- a/benchmarks/evaluate_webcanvas.py
+++ b/benchmarks/evaluate_webcanvas.py
@@ -1,0 +1,176 @@
+import argparse
+import csv
+import json
+import time
+from pathlib import Path
+
+import yaml
+from playwright.sync_api import sync_playwright
+
+from agent.loop import parse_action, contains_sensitive
+from vision.llava_client import VisionModel
+from memory.sqlite_graph import ConversationMemory
+from inference.logs import logger
+from openai import OpenAI
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+import os
+
+_LOCAL_MODEL_PATH = os.getenv("LOCAL_LLM_PATH")
+_local_pipeline = None
+if _LOCAL_MODEL_PATH:
+    try:
+        tok = AutoTokenizer.from_pretrained(_LOCAL_MODEL_PATH)
+        model = AutoModelForCausalLM.from_pretrained(
+            _LOCAL_MODEL_PATH,
+            device_map="auto",
+            torch_dtype="auto",
+            load_in_4bit=True,
+        )
+        _local_pipeline = pipeline("text-generation", model=model, tokenizer=tok)
+        logger.info("Loaded local LLM from %s", _LOCAL_MODEL_PATH)
+    except Exception as e:  # pragma: no cover - environment dependent
+        logger.warning("Failed to load local model: %s", e)
+        _local_pipeline = None
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def execute_action_sync(page, action):
+    if action["type"] == "click":
+        page.click(action["selector"])
+    elif action["type"] == "type":
+        page.fill(action["selector"], action.get("text", ""))
+    elif action["type"] == "press":
+        page.keyboard.press(action["key"])
+
+
+class Agent:
+    browser = None
+
+    def __init__(self, headless: bool = True, model_name: str = "llava-next", vision_checkpoint: str | None = None):
+        self.headless = headless
+        self.model_name = model_name
+        self.vision = VisionModel(model_name, checkpoint_path=vision_checkpoint)
+        self.memory = ConversationMemory(":memory:")
+
+    def _prompt(self, instruction: str, dom: str, vision_desc: str, session_id: str) -> str:
+        history = self.memory.get(session_id)
+        return (
+            "You are a browser automation agent.\nTask: {task}\n{history}\nDOM:\n{dom}\nVISION:\n{vision}\nReply with a JSON action.".format(
+                task=instruction,
+                history="\n".join(f"{r}:{c}" for r, c in history),
+                dom=dom,
+                vision=vision_desc,
+            )
+        )
+
+    def _predict_action(self, prompt: str) -> dict:
+        use_openai = _local_pipeline is None
+        action = None
+        if _local_pipeline:
+            try:
+                out = _local_pipeline(prompt, max_new_tokens=256)[0]["generated_text"]
+                action = parse_action(out)
+            except Exception as e:  # pragma: no cover - runtime dependant
+                logger.warning("Local pipeline failed: %s", e)
+                use_openai = True
+        if use_openai:
+            response = client.chat.completions.create(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": prompt}],
+                tools=[{
+                    "type": "function",
+                    "function": {
+                        "name": "action",
+                        "description": "Browser action",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "type": {"type": "string"},
+                                "selector": {"type": "string"},
+                                "text": {"type": "string"},
+                                "key": {"type": "string"}
+                            }
+                        }
+                    }
+                }]
+            )
+            tool_call = response.choices[0].message.tool_calls[0]
+            action = json.loads(tool_call.function.arguments)
+        return action
+
+    def plan_act_observe(self, page, instruction: str, session_id: str) -> dict:
+        dom = page.content()
+        screenshot_path = f"/tmp/shot_{int(time.time()*1000)}.png"
+        page.screenshot(path=screenshot_path)
+        if contains_sensitive(dom):
+            return {"handoff": screenshot_path}
+        vision_desc = self.vision.describe(screenshot_path)
+        prompt = self._prompt(instruction, dom[:2000], vision_desc, session_id)
+        action = self._predict_action(prompt)
+        self.memory.add(session_id, "assistant", json.dumps(action))
+        execute_action_sync(page, action)
+        return action
+
+
+def load_scenarios(path: str):
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def evaluate_scenarios(scenarios, output_path: str):
+    results = []
+    out_file = Path(output_path)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with sync_playwright() as pw:
+        Agent.browser = pw.chromium
+        browser = pw.chromium.launch(headless=True)
+        for sc in scenarios:
+            context = browser.new_context()
+            page = context.new_page()
+            start = time.time()
+            page.goto(sc["url"])
+            cred = sc.get("credentials")
+            if cred:
+                page.fill("input[type=text]", cred["username"])
+                page.fill("input[type=password]", cred["password"])
+                page.press("input[type=password]", "Enter")
+            agent = Agent(headless=True)
+            steps = 0
+            success = False
+            while steps < sc["max_steps"]:
+                agent.plan_act_observe(page, sc.get("description", sc["name"]), sc["name"])
+                steps += 1
+                if page.query_selector(sc["success_selector"]):
+                    success = True
+                    break
+            duration = time.time() - start
+            results.append({
+                "name": sc["name"],
+                "success": success,
+                "steps": steps,
+                "duration": round(duration, 2)
+            })
+            context.close()
+        browser.close()
+    if output_path.endswith(".json"):
+        with open(output_path, "w") as f:
+            json.dump(results, f, indent=2)
+    else:
+        with open(output_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["name", "success", "steps", "duration"])
+            writer.writeheader()
+            writer.writerows(results)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scenarios", type=str, required=True)
+    parser.add_argument("--output", type=str, required=True)
+    args = parser.parse_args()
+    scenarios = load_scenarios(args.scenarios)
+    evaluate_scenarios(scenarios, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/webcanvas_scenarios.yaml
+++ b/benchmarks/webcanvas_scenarios.yaml
@@ -1,0 +1,12 @@
+- name: login_test
+  url: https://example.com/login
+  success_selector: ".dashboard"
+  max_steps: 5
+  description: Simple login flow
+  credentials:
+    username: user
+    password: pass
+- name: browse
+  url: https://example.com
+  success_selector: "#main"
+  max_steps: 3

--- a/web-dashboard/index.html
+++ b/web-dashboard/index.html
@@ -5,11 +5,56 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="p-4">
   <div id="app"></div>
   <script type="text/javascript">
-    const App = () => React.createElement('div', null, 'History placeholder');
+    const App = () => {
+      const [rows, setRows] = React.useState([]);
+      React.useEffect(() => {
+        fetch('webcanvas_report.csv')
+          .then(r => r.text())
+          .then(t => {
+            const lines = t.trim().split('\n');
+            const headers = lines.shift().split(',');
+            const data = lines.map(l => {
+              const parts = l.split(',');
+              const obj = {};
+              headers.forEach((h, i) => obj[h] = parts[i]);
+              obj.success = obj.success === 'True';
+              obj.steps = Number(obj.steps);
+              obj.duration = Number(obj.duration);
+              return obj;
+            });
+            setRows(data);
+            const successRate = data.filter(d => d.success).length / data.length;
+            const avgTime = data.reduce((a,b)=>a+b.duration,0)/data.length;
+            const avgSteps = data.reduce((a,b)=>a+b.steps,0)/data.length;
+            new Chart(document.getElementById('chart'),{
+              type:'bar',
+              data:{labels:['Success %','Avg time','Avg steps'],datasets:[{label:'Metrics',data:[successRate*100,avgTime,avgSteps]}]},
+              options:{scales:{y:{beginAtZero:true}}}
+            });
+          });
+      },[]);
+      return React.createElement('div', null,
+        React.createElement('h2',{className:'text-xl font-bold mb-2'},'WebCanvas Report'),
+        React.createElement('table',{className:'table-auto border mb-4'},
+          React.createElement('thead',null,
+            React.createElement('tr',null,
+              ['name','success','steps','duration'].map(h=>React.createElement('th',{key:h,className:'border px-2'},h))
+            )
+          ),
+          React.createElement('tbody',null,
+            rows.map((r,i)=>React.createElement('tr',{key:i},[
+              r.name,r.success.toString(),r.steps,r.duration.toFixed(2)
+            ].map((v,j)=>React.createElement('td',{key:j,className:'border px-2'},v))))
+          )
+        ),
+        React.createElement('canvas',{id:'chart',width:400,height:200})
+      );
+    };
     ReactDOM.render(React.createElement(App), document.getElementById('app'));
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add YAML scenarios for WebCanvas evaluation
- implement evaluation and threshold check scripts
- update CI to run WebCanvas evaluation and upload report
- enhance dashboard to display results
- document WebCanvas workflow in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e6fce54248330b82d99b767055873