### PR TITLE
Add prototype Frontend 4 dashboard

### DIFF
--- a/frontend4_operator/README.md
+++ b/frontend4_operator/README.md
@@ -1,0 +1,38 @@
+# Frontend 4 Operator
+
+This folder provides an experimental dashboard that merges ideas from the three proposal archives. It exposes a minimal vanilla JavaScript app with optional 3D and voice features. The dashboard can be served by a FastAPI backend and communicates via WebSockets.
+
+## Features
+- Real-time metrics and agent status via `/ws` WebSocket
+- Voice command button using the Web Speech API
+- Simple 3D canvas powered by Three.js (placeholder for WebXR)
+- Responsive CSS layout with CSS variables
+
+## Running
+1. Install Python requirements:
+   ```bash
+   pip install fastapi uvicorn
+   ```
+2. Start the FastAPI server (`fastapi_app.py` example below):
+   ```bash
+   uvicorn fastapi_app:app --reload --port 7860
+   ```
+3. Open `index.html` in your browser or let FastAPI serve static files from this directory.
+
+## Example FastAPI Backend
+```python
+from fastapi import FastAPI, WebSocket
+from fastapi.staticfiles import StaticFiles
+import json, asyncio
+
+app = FastAPI(title="Open Operator API")
+app.mount("/", StaticFiles(directory="frontend4_operator", html=True), name="static")
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    while True:
+        data = {"metrics": {"active_agents": 1}, "agents": [{"name": "demo", "status": "running"}]}
+        await websocket.send_text(json.dumps(data))
+        await asyncio.sleep(1)
+```

--- a/frontend4_operator/app.js
+++ b/frontend4_operator/app.js
@@ -1,0 +1,80 @@
+const metricsList = document.getElementById('metrics-list');
+const agentsList = document.getElementById('agents-list');
+const canvas = document.getElementById('xr-canvas');
+let ws;
+
+function connectWebSocket() {
+    ws = new WebSocket(`ws://${location.host}/ws`);
+    ws.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        updateDashboard(data);
+    };
+    ws.onclose = () => {
+        setTimeout(connectWebSocket, 1000);
+    };
+}
+
+function updateDashboard(data) {
+    if (data.metrics) {
+        metricsList.innerHTML = '';
+        Object.entries(data.metrics).forEach(([key, value]) => {
+            const li = document.createElement('li');
+            li.textContent = `${key}: ${value}`;
+            metricsList.appendChild(li);
+        });
+    }
+    if (data.agents) {
+        agentsList.innerHTML = '';
+        data.agents.forEach(agent => {
+            const li = document.createElement('li');
+            li.textContent = `${agent.name} - ${agent.status}`;
+            agentsList.appendChild(li);
+        });
+    }
+}
+
+// Voice commands using Web Speech API
+const voiceBtn = document.getElementById('voice-btn');
+const recognition = window.SpeechRecognition ? new window.SpeechRecognition() : new window.webkitSpeechRecognition();
+recognition.lang = 'en-US';
+voiceBtn.onclick = () => {
+    recognition.start();
+};
+
+recognition.onresult = (event) => {
+    const transcript = event.results[0][0].transcript;
+    ws.send(JSON.stringify({ type: 'voice_command', text: transcript }));
+};
+
+// Basic 3D scene using Three.js
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.163.0/build/three.module.js';
+
+let scene, camera, renderer, cube;
+function init3D() {
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(75, canvas.clientWidth / canvas.clientHeight, 0.1, 1000);
+    renderer = new THREE.WebGLRenderer({ canvas });
+    renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+    cube = new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshStandardMaterial({ color: 0x4f46e5 }));
+    scene.add(cube);
+    const light = new THREE.HemisphereLight(0xffffff, 0x444444);
+    scene.add(light);
+    camera.position.z = 3;
+    animate();
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+    cube.rotation.x += 0.01;
+    cube.rotation.y += 0.01;
+    renderer.render(scene, camera);
+}
+
+window.addEventListener('resize', () => {
+    camera.aspect = canvas.clientWidth / canvas.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+});
+
+connectWebSocket();
+init3D();

--- a/frontend4_operator/fastapi_app.py
+++ b/frontend4_operator/fastapi_app.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI, WebSocket
+from fastapi.staticfiles import StaticFiles
+import asyncio, json
+
+app = FastAPI(title="Open Operator API")
+app.mount("/", StaticFiles(directory=".", html=True), name="static")
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    while True:
+        data = {
+            "metrics": {"active_agents": 1, "success_rate": 0.95},
+            "agents": [
+                {"name": "demo-agent", "status": "running"}
+            ]
+        }
+        await websocket.send_text(json.dumps(data))
+        await asyncio.sleep(1)

--- a/frontend4_operator/index.html
+++ b/frontend4_operator/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Open Operator Dashboard 4</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="header">
+        <h1>Open Operator 4</h1>
+        <div class="controls">
+            <button id="voice-btn" title="Start voice commands">🎤</button>
+        </div>
+    </header>
+
+    <main class="grid">
+        <section id="metrics" class="card">
+            <h2>Metrics</h2>
+            <ul id="metrics-list"></ul>
+        </section>
+
+        <section id="agents" class="card">
+            <h2>Agents</h2>
+            <ul id="agents-list"></ul>
+        </section>
+
+        <section id="canvas-wrapper" class="card full">
+            <h2>3D View</h2>
+            <canvas id="xr-canvas"></canvas>
+        </section>
+    </main>
+
+    <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/frontend4_operator/style.css
+++ b/frontend4_operator/style.css
@@ -1,0 +1,53 @@
+:root {
+    --bg: #f8fafc;
+    --fg: #1e293b;
+    --accent: #4f46e5;
+}
+
+body {
+    margin: 0;
+    font-family: system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    background: var(--accent);
+    color: white;
+}
+
+.controls button {
+    background: transparent;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: white;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1rem;
+    padding: 1rem;
+}
+
+.card {
+    background: white;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.full {
+    grid-column: 1 / -1;
+}
+
+#xr-canvas {
+    width: 100%;
+    height: 400px;
+    background: #000;
+}


### PR DESCRIPTION
## Summary
- create `frontend4_operator` prototype dashboard
- implement vanilla JS/Three.js frontend with voice commands and websocket
- include example FastAPI backend and README

## Testing
- `python cli.py test` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_685fc6237af083308993aaf5cb7d8d42